### PR TITLE
Update ietf_quic_hosts.txt

### DIFF
--- a/ietf_quic_hosts.txt
+++ b/ietf_quic_hosts.txt
@@ -15,7 +15,6 @@ quic.tech:4433	/index.html	8443	hq
 quic.aiortc.org:443	/	443	hq
 quic.seemann.io:443	/	443	h3
 pandora.cm.in.tum.de:4433	/index.html	4433	hq
-ietf.akaquic.com:443	/	443	h3
 test.pquic.org:443	/	443	hq
 mew.org:443	/	443	hq
 www.haproxy.org:443	/	443	h3


### PR DESCRIPTION
@haproxyFred ietf.akaquic.com is being removed due to decommissioning.